### PR TITLE
Ignore more complex enum values

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,7 +41,9 @@ func resolveValue(value ast.Expr, ty ast.Expr, found map[string]Value) Value {
 		return Value{Type: fmt.Sprintf("%v", ty), Value: "-" + v2.Value}
 	}
 
-	panic(value)
+	// Any other case we encounter we will assume it's too complicated to
+	// understand.
+	return Value{Type: "<nil>"}
 }
 
 func appendEnumValues(in map[string]Value, decl *ast.GenDecl) {

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -6,4 +6,4 @@
 Bar [BarA BarD BarE]
 Foo [BarC FooA FooB FooC FooD FooE]
 ./test/bar.go:23:3 switch is missing cases for: BarE
-./test/foo.go:33:2 switch is missing cases for: BarC, FooB, FooE
+./test/foo.go:37:2 switch is missing cases for: BarC, FooB, FooE

--- a/test/foo.go
+++ b/test/foo.go
@@ -20,6 +20,10 @@ var FooE = Foo(-1)
 // Ignored because not of type Foo
 const FooF = 123
 
+// This will not be understood as an enum value because of the complex
+// expression.
+const FooG = FooA + 2
+
 func ignoredSwitch1() {
 	switch {
 	case true:


### PR DESCRIPTION
Previously it would panic (this was just left over debugging code) now
these cases are just ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/switch-check/3)
<!-- Reviewable:end -->
