### PR TITLE
Avoid panic when cast might be a function call

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,12 @@ func resolveValue(value ast.Expr, ty ast.Expr, found map[string]Value) Value {
 		return Value{Type: fmt.Sprintf("%v", ty), Value: v.Value}
 
 	case *ast.CallExpr:
+		// If there are no args this means it must be a call to a function.
+		// Which we don't support.
+		if len(v.Args) != 1 {
+			return Value{Type: "<nil>"}
+		}
+
 		v2 := resolveValue(v.Args[0], ty, found)
 		return Value{Type: fmt.Sprintf("%v", v.Fun), Value: v2.Value}
 

--- a/test/bar.go
+++ b/test/bar.go
@@ -10,6 +10,17 @@ var (
 	BarE     = Bar("e")
 )
 
+// BarF is too complex to understand. More importantly because there are no
+// arguments we shouldn't think NewBar is a type.
+var (
+	BarF = NewBar()
+	BarG = NewBar("a", 123)
+)
+
+func NewBar(_ ...interface{}) Bar {
+	return BarA
+}
+
 func hasAllBars() {
 	var bar Bar
 	switch bar {

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -5,5 +5,5 @@
 # ./test/foo.go
 Bar [BarA BarD BarE]
 Foo [BarC FooA FooB FooC FooD FooE]
-./test/bar.go:23:3 switch is missing cases for: BarE
+./test/bar.go:34:3 switch is missing cases for: BarE
 ./test/foo.go:37:2 switch is missing cases for: BarC, FooB, FooE


### PR DESCRIPTION
From the AST we cannot tell (reliably right now) if "Bar(1)" is a
function call to bar, or casting the value 1 to Bar. However, we can
certainly tell that "Bar()" and "Bar(1, 2)" would not be type casting so
we should ignore these cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/switch-check/4)
<!-- Reviewable:end -->
