### PR TITLE
Ignore obvious function calls

### DIFF
--- a/test/expected.txt
+++ b/test/expected.txt
@@ -6,4 +6,4 @@
 Bar [BarA BarD BarE]
 Foo [BarC FooA FooB FooC FooD FooE]
 ./test/bar.go:34:3 switch is missing cases for: BarE
-./test/foo.go:37:2 switch is missing cases for: BarC, FooB, FooE
+./test/foo.go:42:2 switch is missing cases for: BarC, FooB, FooE

--- a/test/foo.go
+++ b/test/foo.go
@@ -1,5 +1,7 @@
 package test
 
+import "regexp"
+
 type Foo int
 
 // Define multiple enum values.
@@ -23,6 +25,9 @@ const FooF = 123
 // This will not be understood as an enum value because of the complex
 // expression.
 const FooG = FooA + 2
+
+// Make sure "regexp.MustCompile" is not considered a type.
+var alnumOrDashRegexp = regexp.MustCompile("[^a-z_0-9-]+")
 
 func ignoredSwitch1() {
 	switch {


### PR DESCRIPTION
It's not always obvious when a function call is a type cast or a
function call (right now). However, there are some cases that are
clearly not types and can be avoided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/switch-check/5)
<!-- Reviewable:end -->
