### PR TITLE
Recognise wrapped iota

### DIFF
--- a/test/baz.go
+++ b/test/baz.go
@@ -1,0 +1,24 @@
+package test
+
+type Baz int64
+
+const (
+	// Since we are casting iota the type also carried down to BazB and BazC.
+	BazA = Baz(iota)
+	BazB
+	BazC
+)
+
+func allBaz() {
+	var b Baz
+	switch b {
+	case BazA, BazB, BazC:
+	}
+}
+
+func missingSomeBaz() {
+	var b Baz
+	switch b {
+	case BazC:
+	}
+}

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -2,8 +2,11 @@
 # ./main_test.go
 # ./switch.go
 # ./test/bar.go
+# ./test/baz.go
 # ./test/foo.go
 Bar [BarA BarD BarE]
+Baz [BazA BazB BazC]
 Foo [BarC FooA FooB FooC FooD FooE]
 ./test/bar.go:34:3 switch is missing cases for: BarE
+./test/baz.go:21:2 switch is missing cases for: BazA, BazB
 ./test/foo.go:42:2 switch is missing cases for: BarC, FooB, FooE


### PR DESCRIPTION
When iota is wrapped in a function the type like "BazA = Baz(iota)" the
type of iota changes as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/switch-check/6)
<!-- Reviewable:end -->
