### PR TITLE
Ignore inbuilt types

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,6 +60,32 @@ func resolveValue(value ast.Expr, ty ast.Expr, found map[string]Value) Value {
 	return Value{}
 }
 
+var inBuiltTypes = map[string]struct{}{
+	"int8":    {},
+	"int16":   {},
+	"int32":   {},
+	"int64":   {},
+	"uint8":   {},
+	"uint16":  {},
+	"uint32":  {},
+	"uint64":  {},
+	"int":     {},
+	"uint":    {},
+	"rune":    {},
+	"byte":    {},
+	"uintptr": {},
+}
+
+func isCastToInBuiltType(t ast.Expr) bool {
+	if i, ok := t.(*ast.CallExpr); ok {
+		_, ok := inBuiltTypes[fmt.Sprintf("%v", i.Fun)]
+
+		return ok
+	}
+
+	return false
+}
+
 func getIotaType(ty ast.Expr, values []ast.Expr) ast.Expr {
 	if len(values) == 0 {
 		return nil
@@ -112,7 +138,9 @@ func appendEnumValues(in map[string]Value, decl *ast.GenDecl) {
 					ty = iotaType
 				}
 
-				in[name.String()] = resolveValue(valueSpec.Values[i], ty, in)
+				if !isCastToInBuiltType(valueSpec.Values[i]) {
+					in[name.String()] = resolveValue(valueSpec.Values[i], ty, in)
+				}
 			}
 		}
 	}

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -4,6 +4,7 @@
 # ./test/bar.go
 # ./test/baz.go
 # ./test/foo.go
+# ./test/inbuilt.go
 Bar [BarA BarD BarE]
 Baz [BazA BazB BazC]
 Foo [BarC FooA FooB FooC FooD FooE]

--- a/test/inbuilt.go
+++ b/test/inbuilt.go
@@ -1,0 +1,19 @@
+package test
+
+// These are all inbuilt and should not be considered enum types.
+
+const (
+	InbuiltA = int8(0)
+	InbuiltB = int16(0)
+	InbuiltC = int32(0)
+	InbuiltD = int64(0)
+	InbuiltE = uint8(0)
+	InbuiltF = uint16(0)
+	InbuiltG = uint32(0)
+	InbuiltH = uint64(0)
+	InbuiltI = int(0)
+	InbuiltJ = uint(0)
+	InbuiltK = rune(0)
+	InbuiltL = byte(0)
+	InbuiltM = uintptr(0)
+)


### PR DESCRIPTION
Function calls to inbuilt types like "float64(1)" should be ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/switch-check/7)
<!-- Reviewable:end -->
