### PR TITLE
Ignore constants that do not belong to an enum

### DIFF
--- a/switch.go
+++ b/switch.go
@@ -65,9 +65,15 @@ func findMissingValues(allValues map[string]Value, values []string) []string {
 	// Otherwise we assume that all values should appear.
 	var missing []string
 	ty := allValues[values[0]]
-	for name, value := range allValues {
-		if value.Type == ty.Type {
-			missing = append(missing, name)
+
+	// If Type is empty then the enum type is not known. We shouldn't add any
+	// missing values in this case. Otherwise it would add every constant that
+	// was unresolved.
+	if ty.Type != "" {
+		for name, value := range allValues {
+			if value.Type == ty.Type {
+				missing = append(missing, name)
+			}
 		}
 	}
 

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -5,6 +5,7 @@
 # ./test/baz.go
 # ./test/foo.go
 # ./test/inbuilt.go
+# ./test/literals.go
 Bar [BarA BarD BarE]
 Baz [BazA BazB BazC]
 Foo [BarC FooA FooB FooC FooD FooE]

--- a/test/literals.go
+++ b/test/literals.go
@@ -1,0 +1,14 @@
+package test
+
+// Some tests for literals that should not be be included as enum values.
+
+const (
+	LiteralA = -1
+)
+
+func useLiteralConstant() {
+	var i int
+	switch i {
+	case LiteralA:
+	}
+}


### PR DESCRIPTION
If a constant was used in a switch that didn't belong to a specific enum
it was considered to belong to all values that do not belong to an enum.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/switch-check/9)
<!-- Reviewable:end -->
