### PR TITLE
Support enums used across packages

### DIFF
--- a/switch.go
+++ b/switch.go
@@ -1,21 +1,12 @@
 package main
 
 import (
-	"fmt"
 	"go/ast"
-	"go/parser"
 	"go/token"
-	"log"
 	"sort"
 )
 
-func getSwitchesFromFile(path string) map[string][]string {
-	fset := token.NewFileSet()
-	node, err := parser.ParseFile(fset, path, nil, 0)
-	if err != nil {
-		log.Panic(err)
-	}
-
+func getSwitchesFromFile(fset *token.FileSet, node *ast.File, currentPackage string, pkgs map[string]string) map[string][]string {
 	found := map[string][]string{}
 
 	ast.Inspect(node, func(n ast.Node) bool {
@@ -29,7 +20,7 @@ func getSwitchesFromFile(path string) map[string][]string {
 						hasDefault = true
 					}
 					for _, caseValueValue := range caseClauseValues.List {
-						found[pos] = append(found[pos], fmt.Sprintf("%v", caseValueValue))
+						found[pos] = append(found[pos], getTypeName(caseValueValue, currentPackage, pkgs))
 					}
 				}
 			}

--- a/test/another-pkg/qux.go
+++ b/test/another-pkg/qux.go
@@ -1,0 +1,6 @@
+package anotherpkg
+
+type Qux bool
+
+const QuxYes = Qux(true)
+const QuxNo = Qux(false)

--- a/test/another-pkg/reference-foo.go
+++ b/test/another-pkg/reference-foo.go
@@ -1,0 +1,16 @@
+// Notice the package name here is different from the directory.
+
+package anotherpkg
+
+import "github.com/elliotchance/switch-check/test"
+
+const BazD = test.Baz(1234)
+
+func fooRefMissingSomeValues() {
+	foo := test.FooB
+
+	switch foo {
+	case test.FooA:
+	case test.FooB:
+	}
+}

--- a/test/baz.go
+++ b/test/baz.go
@@ -1,5 +1,7 @@
 package test
 
+import "github.com/elliotchance/switch-check/test/another-pkg"
+
 type Baz int64
 
 const (
@@ -12,7 +14,7 @@ const (
 func allBaz() {
 	var b Baz
 	switch b {
-	case BazA, BazB, BazC:
+	case BazA, BazB, BazC, anotherpkg.BazD:
 	}
 }
 

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -1,14 +1,34 @@
 # ./main.go
 # ./main_test.go
 # ./switch.go
+# ./test/another-pkg/qux.go
+# ./test/another-pkg/reference-foo.go
 # ./test/bar.go
 # ./test/baz.go
 # ./test/foo.go
 # ./test/inbuilt.go
 # ./test/literals.go
-Bar [BarA BarD BarE]
-Baz [BazA BazB BazC]
-Foo [BarC FooA FooB FooC FooD FooE]
-./test/bar.go:34:3 switch is missing cases for: BarE
-./test/baz.go:21:2 switch is missing cases for: BazA, BazB
-./test/foo.go:42:2 switch is missing cases for: BarC, FooB, FooE
+github.com/elliotchance/switch-check/test.Bar
+  BarA
+  BarD
+  BarE
+github.com/elliotchance/switch-check/test.Baz
+  BazA
+  BazB
+  BazC
+  BazD (in github.com/elliotchance/switch-check/test/another-pkg)
+github.com/elliotchance/switch-check/test.Foo
+  BarC
+  FooA
+  FooB
+  FooC
+  FooE
+github.com/elliotchance/switch-check/test/another-pkg.Qux
+  QuxNo
+  QuxYes
+regexp.MustCompile
+  alnumOrDashRegexp (in github.com/elliotchance/switch-check/test)
+./test/another-pkg/reference-foo.go:12:2 switch is missing cases for: github.com/elliotchance/switch-check/test.BarC, github.com/elliotchance/switch-check/test.FooC, github.com/elliotchance/switch-check/test.FooE
+./test/bar.go:34:3 switch is missing cases for: github.com/elliotchance/switch-check/test.BarE
+./test/baz.go:23:2 switch is missing cases for: github.com/elliotchance/switch-check/test.BazA, github.com/elliotchance/switch-check/test.BazB, github.com/elliotchance/switch-check/test/another-pkg.BazD
+./test/foo.go:42:2 switch is missing cases for: github.com/elliotchance/switch-check/test.BarC, github.com/elliotchance/switch-check/test.FooB, github.com/elliotchance/switch-check/test.FooE


### PR DESCRIPTION
All of the types and enum names have to be fully-qualified with their
package name so that usages across packages can be identified.

Also cleaned up "-show-enums" into a multiline that is easier to read
(it's still not a porcelain format).

Go lets you specify a different package name in the source files from
the directory they reside in. Right now I haven't built a way to fetch
all the real package names from the directories so I'll just assume that
people would only remove punctuation (like a dash or underscore).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/switch-check/10)
<!-- Reviewable:end -->
